### PR TITLE
Fix: Check $globals for value in activity API request

### DIFF
--- a/src/API/ActivityController.php
+++ b/src/API/ActivityController.php
@@ -83,7 +83,8 @@ final class ActivityController extends BaseApiController
             $query->setOrderBy($orderBy);
         }
 
-        if (null !== $paramFetcher->get('globals')) {
+        $globals = $paramFetcher->get('globals');
+        if (\is_string($globals) && $globals == 'true') {
             $query->setGlobalsOnly(true);
         }
 

--- a/src/API/ActivityController.php
+++ b/src/API/ActivityController.php
@@ -84,7 +84,7 @@ final class ActivityController extends BaseApiController
         }
 
         $globals = $paramFetcher->get('globals');
-        if (\is_string($globals) && $globals == 'true') {
+        if (\is_string($globals) && $globals === 'true') {
             $query->setGlobalsOnly(true);
         }
 


### PR DESCRIPTION
## Description
Closes #5283. Checks `$paramFetcher->get('globals')` for string 'true' and activates globals only activities in API query.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
